### PR TITLE
Feat/shield

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 .DS_Store
 *.swp
 .tmp
+.openzeppelin/unknown-31337.json

--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,4 @@
 .DS_Store
 *.swp
 .tmp
-.openzeppelin/unknown-31337.json
+/.openzeppelin/unknown-31337.json

--- a/.openzeppelin/unknown-31337.json
+++ b/.openzeppelin/unknown-31337.json
@@ -190,8 +190,8 @@
       }
     },
     "16eb2d598a98c1b50ee4e5d1b76001180b1fbfbd5b86f451536394b46b1b2c8f": {
-      "address": "0xD5c1b3Df7E630cBfa4cA7ea37D76cb0dD13F7154",
-      "txHash": "0x4443f00d1ab4c9aa9d217e0a8615b34f764c5c01381ef9163172cc1de7f2dc93",
+      "address": "0xC94C872deB2e982887C8566fF4085B24823D33D0",
+      "txHash": "0xb6c065b247fbbf54a48e05584566733ebb3c9d9bd8158e086161c22a11035610",
       "layout": {
         "storage": [
           {
@@ -260,8 +260,8 @@
       }
     },
     "d7ce81080628c6da5f97d698a902da85f7578fa00b96a7f747803be4f8388144": {
-      "address": "0xA84213ac88cA1d4ee1326d8f5663e5b638837999",
-      "txHash": "0xe9c2ddad731924ae3b72fd8881eca1d3cecd216c371fe38c1e734b1b894f1a52",
+      "address": "0x796a99E37C2225e3AD7b8AaB6fc25F8398975F67",
+      "txHash": "0xa1babf6a53b2e963d1870b4b89812acf9309db389bdae89bcb4805fe5ac81dc5",
       "layout": {
         "storage": [
           {
@@ -393,8 +393,8 @@
       }
     },
     "7e7f6b47b25e8cd1cdd270eb6ef5de787c564e0a1b509bb323141430130ff0c8": {
-      "address": "0xC0FbC62e9237C86c4f082f1f290667A54155D81a",
-      "txHash": "0xb2407c99f31e830d238bc0f944e5a43ae2dd38f19b008d1997296f9ebdc47d88",
+      "address": "0xB49f7A97920876d2Ea99903Bce5C8aF948506914",
+      "txHash": "0xa08dc51465a8f9c9c6a08f4db0a5a29c092e9bfec582d4d3666dae515713bf5a",
       "layout": {
         "storage": [
           {
@@ -814,8 +814,8 @@
       }
     },
     "e5176cef0c3d0fd30d509ac44387fdbc45ad0c475cd081f858c21dd071cc597f": {
-      "address": "0x925232A4f056f776cA89dcc541fE9f2E001686e9",
-      "txHash": "0x2e88ca059be0fa6e73e916c762170b0444adc28951e1faa1263942c544dd3a71",
+      "address": "0x73cAF30eE07EEcEeAF8d872e30D663693DA4487A",
+      "txHash": "0xdc5b6cf077ac35c814c1fe1d6bb021809215076d2aaee84f9d8f5269e2d7b634",
       "layout": {
         "storage": [
           {
@@ -948,13 +948,13 @@
           {
             "contract": "StrategyAddTwoSidesOptimal",
             "label": "router",
-            "type": "t_contract(IUniswapV2Router02)8712",
+            "type": "t_contract(IUniswapV2Router02)8704",
             "src": "contracts/6/protocol/strategies/pancakeswap/StrategyAddTwoSidesOptimal.sol:23"
           },
           {
             "contract": "StrategyAddTwoSidesOptimal",
             "label": "vault",
-            "type": "t_contract(IVault)11602",
+            "type": "t_contract(IVault)11594",
             "src": "contracts/6/protocol/strategies/pancakeswap/StrategyAddTwoSidesOptimal.sol:24"
           }
         ],
@@ -962,10 +962,10 @@
           "t_contract(IUniswapV2Factory)3151": {
             "label": "contract IUniswapV2Factory"
           },
-          "t_contract(IUniswapV2Router02)8712": {
+          "t_contract(IUniswapV2Router02)8704": {
             "label": "contract IUniswapV2Router02"
           },
-          "t_contract(IVault)11602": {
+          "t_contract(IVault)11594": {
             "label": "contract IVault"
           },
           "t_bool": {
@@ -1027,7 +1027,7 @@
           {
             "contract": "StrategyWithdrawMinimizeTrading",
             "label": "router",
-            "type": "t_contract(IUniswapV2Router02)8712",
+            "type": "t_contract(IUniswapV2Router02)8704",
             "src": "contracts/6/protocol/strategies/pancakeswap/StrategyWithdrawMinimizeTrading.sol:19"
           }
         ],
@@ -1035,7 +1035,7 @@
           "t_contract(IUniswapV2Factory)3151": {
             "label": "contract IUniswapV2Factory"
           },
-          "t_contract(IUniswapV2Router02)8712": {
+          "t_contract(IUniswapV2Router02)8704": {
             "label": "contract IUniswapV2Router02"
           },
           "t_bool": {
@@ -1054,8 +1054,8 @@
       }
     },
     "7f29d4fd64f3656c2c27c15f92ba44e0910ee99be21b0bcbc9fd9c46f4b6044d": {
-      "address": "0x0A30d75152853cb69675CAa55553ad06199f2Dd1",
-      "txHash": "0x5444223663a24e614bb647fd112f04758718c44cf961e0a54af1d4ede0436568",
+      "address": "0x68343eA3C09FD2D40178cdc087883a4dc26dec2c",
+      "txHash": "0x28448eb42d8f657b54ea9df7da9267259499cf4caf8ead1b29f36e34901350d5",
       "layout": {
         "storage": [
           {
@@ -1115,7 +1115,7 @@
           {
             "contract": "ConfigurableInterestVaultConfig",
             "label": "workers",
-            "type": "t_mapping(t_address,t_contract(IWorkerConfig)11780)",
+            "type": "t_mapping(t_address,t_contract(IWorkerConfig)11778)",
             "src": "contracts/6/protocol/ConfigurableInterestVaultConfig.sol:48"
           },
           {
@@ -1147,13 +1147,13 @@
           "t_uint256": {
             "label": "uint256"
           },
-          "t_mapping(t_address,t_contract(IWorkerConfig)11780)": {
+          "t_mapping(t_address,t_contract(IWorkerConfig)11778)": {
             "label": "mapping(address => contract IWorkerConfig)"
           },
           "t_address": {
             "label": "address"
           },
-          "t_contract(IWorkerConfig)11780": {
+          "t_contract(IWorkerConfig)11778": {
             "label": "contract IWorkerConfig"
           },
           "t_contract(InterestModel)3918": {
@@ -1172,8 +1172,8 @@
       }
     },
     "d7b62848423c8c0885c38c4c3c2e724470e136b5731686ae9a38e21a2cdd088b": {
-      "address": "0x235Ca007b0Bc680Fe204e897f2a3146f099f71Fb",
-      "txHash": "0x9fc7e5227bb1098b4ee872839aee69347b69e7acf2ba125e4e866d82353ac117",
+      "address": "0x54fb978Cd810E26202496Ba1Be6e85cF6CCfdd02",
+      "txHash": "0x095ed9c7f458078ba86f2cfc3544367f34589fcb525cbcbd7dc73d131b3375b0",
       "layout": {
         "storage": [
           {
@@ -1270,8 +1270,8 @@
       }
     },
     "6c883b146c73b165c5657fe34f9eb19c86870b61d1141bb7bcfe3617158d2576": {
-      "address": "0x50690dFBDF9F121640eCA72d57348BB0A073ffDE",
-      "txHash": "0x4598d5b518ec30fed30cc1c238b8ddbc2b122013213214c7796cfd922329f7c9",
+      "address": "0x5e06e0E3Dec59D54E93F3Bdd621184508DEB2a94",
+      "txHash": "0xc59f81f6de2c1d39ec19b12a53ddb325de62f5323605afe89ebff033d83b6a2d",
       "layout": {
         "storage": [
           {
@@ -1314,26 +1314,26 @@
             "contract": "WorkerConfig",
             "label": "oracle",
             "type": "t_contract(PriceOracle)6127",
-            "src": "contracts/6/protocol/workers/WorkerConfig.sol:29"
+            "src": "contracts/6/protocol/workers/WorkerConfig.sol:24"
           },
           {
             "contract": "WorkerConfig",
             "label": "workers",
-            "type": "t_mapping(t_address,t_struct(Config)14432_storage)",
-            "src": "contracts/6/protocol/workers/WorkerConfig.sol:30"
+            "type": "t_mapping(t_address,t_struct(Config)14423_storage)",
+            "src": "contracts/6/protocol/workers/WorkerConfig.sol:25"
           }
         ],
         "types": {
           "t_contract(PriceOracle)6127": {
             "label": "contract PriceOracle"
           },
-          "t_mapping(t_address,t_struct(Config)14432_storage)": {
+          "t_mapping(t_address,t_struct(Config)14423_storage)": {
             "label": "mapping(address => struct WorkerConfig.Config)"
           },
           "t_address": {
             "label": "address"
           },
-          "t_struct(Config)14432_storage": {
+          "t_struct(Config)14423_storage": {
             "label": "struct WorkerConfig.Config",
             "members": [
               {
@@ -1373,8 +1373,8 @@
       }
     },
     "c3688dc9026033a75223d5cec6e2662d54afd9726b0bb416f57c96f49f9d033d": {
-      "address": "0x1284a28a6d1a3B52B1d4412791B721114c6996fd",
-      "txHash": "0x5b8913b48ef70a95c6d287f078a947fcfb96c4ab2b461de68f1f89715f3ea66c",
+      "address": "0x5EF0C6E857F16977A1b001ABf0726B9D7153393D",
+      "txHash": "0x82dd33900abbe6ae395b2dd7971717d7a3e2d97957e29ea777b704534f20cf6b",
       "layout": {
         "storage": [
           {
@@ -1596,6 +1596,76 @@
           },
           "t_array(t_uint256)44_storage": {
             "label": "uint256[44]"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]"
+          }
+        }
+      }
+    },
+    "18dec4a6813dec4f9c2026d349308546bc2e91b2aad50ada15c4d61cf4cea03b": {
+      "address": "0x3326943a5Ba444df683811505f02b5a31217C916",
+      "txHash": "0xc062580ca22ededf6196b26f2e1b2015053a18ab083728e1986916c31e87ac12",
+      "layout": {
+        "storage": [
+          {
+            "contract": "Initializable",
+            "label": "initialized",
+            "type": "t_bool",
+            "src": "@openzeppelin/contracts-ethereum-package/contracts/Initializable.sol:21"
+          },
+          {
+            "contract": "Initializable",
+            "label": "initializing",
+            "type": "t_bool",
+            "src": "@openzeppelin/contracts-ethereum-package/contracts/Initializable.sol:26"
+          },
+          {
+            "contract": "Initializable",
+            "label": "______gap",
+            "type": "t_array(t_uint256)50_storage",
+            "src": "@openzeppelin/contracts-ethereum-package/contracts/Initializable.sol:61"
+          },
+          {
+            "contract": "ReentrancyGuardUpgradeSafe",
+            "label": "_notEntered",
+            "type": "t_bool",
+            "src": "@openzeppelin/contracts-ethereum-package/contracts/utils/ReentrancyGuard.sol:21"
+          },
+          {
+            "contract": "ReentrancyGuardUpgradeSafe",
+            "label": "__gap",
+            "type": "t_array(t_uint256)49_storage",
+            "src": "@openzeppelin/contracts-ethereum-package/contracts/utils/ReentrancyGuard.sol:63"
+          },
+          {
+            "contract": "StrategyAddBaseTokenOnly",
+            "label": "factory",
+            "type": "t_contract(IUniswapV2Factory)3151",
+            "src": "contracts/6/protocol/strategies/pancakeswap/StrategyAddBaseTokenOnly.sol:20"
+          },
+          {
+            "contract": "StrategyAddBaseTokenOnly",
+            "label": "router",
+            "type": "t_contract(IUniswapV2Router02)8704",
+            "src": "contracts/6/protocol/strategies/pancakeswap/StrategyAddBaseTokenOnly.sol:21"
+          }
+        ],
+        "types": {
+          "t_contract(IUniswapV2Factory)3151": {
+            "label": "contract IUniswapV2Factory"
+          },
+          "t_contract(IUniswapV2Router02)8704": {
+            "label": "contract IUniswapV2Router02"
+          },
+          "t_bool": {
+            "label": "bool"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]"
+          },
+          "t_uint256": {
+            "label": "uint256"
           },
           "t_array(t_uint256)50_storage": {
             "label": "uint256[50]"

--- a/contracts/6/protocol/strategies/pancakeswap/StrategyAddBaseTokenOnly.sol
+++ b/contracts/6/protocol/strategies/pancakeswap/StrategyAddBaseTokenOnly.sol
@@ -57,7 +57,7 @@ contract StrategyAddBaseTokenOnly is ReentrancyGuardUpgradeSafe, IStrategy {
     router.swapExactTokensForTokens(aIn, 0, path, address(this), now);
     // 4. Mint more LP tokens and return all LP tokens to the sender.
     quoteToken.safeApprove(address(router), 0);
-    quoteToken.safeApprove(address(router), uint(-1));
+    quoteToken.safeApprove(address(router), quoteToken.myBalance());
     (,, uint256 moreLPAmount) = router.addLiquidity(
       baseToken, quoteToken, IERC20(baseToken).balanceOf(address(this)), quoteToken.myBalance(), 0, 0, address(this), now
     );

--- a/contracts/6/token/Shield.sol
+++ b/contracts/6/token/Shield.sol
@@ -1,0 +1,70 @@
+pragma solidity 0.6.6;
+
+import "@openzeppelin/contracts/access/Ownable.sol";
+import "@openzeppelin/contracts/math/SafeMath.sol";
+
+import "./interfaces/IFairLaunchV1.sol";
+
+contract Shield is Ownable {
+  using SafeMath for uint256;
+
+  IFairLaunchV1 public fairLaunchV1;
+
+  uint256 public mintLimit = 8000000e18;
+  uint256 public mintCount = 250000e18;
+
+  event SetAlpacaPerBlock(uint256 indexed _alpacaPerBlock);
+  event SetBonus(uint256 _bonusMultiplier, uint256 _bonusEndBlock, uint256 _bonusLockUpBps);
+  event MintWarchest(address indexed _to, uint256 _amount);
+  event AddPool(uint256 indexed _pid, uint256 _allocPoint, address indexed _stakeToken);
+  event SetPool(uint256 indexed _pid, uint256 _allocPoint);
+
+  constructor(address _owner, IFairLaunchV1 _fairLaunchV1) public {
+    transferOwnership(_owner);
+    fairLaunchV1 = _fairLaunchV1;
+  }
+
+  /// @dev Set ALPACA per Block on FLV1. Effect immediately on the next block.
+  /// @param _alpacaPerBlock The new alpacaPerBlock
+  function setAlpacaPerBlock(uint256 _alpacaPerBlock) public onlyOwner {
+    fairLaunchV1.setAlpacaPerBlock(_alpacaPerBlock);
+    emit SetAlpacaPerBlock(_alpacaPerBlock);
+  }
+
+  /// @dev Set Bonus period on FLV1. This shouldn't be used much. Better use FLV2
+  /// @param _bonusMultiplier New bonusMultiplier
+  /// @param _bonusEndBlock The block that this bonus will be ended
+  /// @param _bonusLockUpBps The % that will rewards on bonus period will be locked
+  function setBonus(uint256 _bonusMultiplier, uint256 _bonusEndBlock, uint256 _bonusLockUpBps) public onlyOwner {
+    fairLaunchV1.setBonus(_bonusMultiplier, _bonusEndBlock, _bonusLockUpBps);
+    emit SetBonus(_bonusMultiplier, _bonusEndBlock, _bonusLockUpBps);
+  }
+
+  /// @dev Maunally mint ALPACA warchest portion.
+  /// @param _to Mint to which address
+  /// @param _amount Amount to be minted
+  function mintWarchest(address _to, uint256 _amount) public onlyOwner {
+    require(mintCount.add(_amount) <= mintLimit, "shield: mint exceeded mintLimit");
+    fairLaunchV1.manualMint(_to, _amount);
+    mintCount = mintCount.add(_amount);
+    emit MintWarchest(_to, _amount);
+  }
+
+  /// @dev Add new pool to FLV1
+  /// @param _allocPoint Allocation point of a new pool
+  /// @param _stakeToken Token to be staked
+  /// @param _withUpdate Mass update pool?
+  function addPool(uint256 _allocPoint, address _stakeToken, bool _withUpdate) public onlyOwner {
+    fairLaunchV1.addPool(_allocPoint, _stakeToken, _withUpdate);
+    emit AddPool(fairLaunchV1.poolLength().sub(1), _allocPoint, _stakeToken);
+  }
+
+  /// @dev Set pool on FLV1. Update pool allocation point
+  /// @param _pid PoolId to be updated
+  /// @param _allocPoint New allocPoint
+  /// @param _withUpdate Mass update pool?
+  function setPool(uint256 _pid, uint256 _allocPoint, bool _withUpdate) public onlyOwner {
+    fairLaunchV1.setPool(_pid, _allocPoint, _withUpdate);
+    emit SetPool(_pid, _allocPoint);
+  }
+}

--- a/contracts/6/token/interfaces/IFairLaunchV1.sol
+++ b/contracts/6/token/interfaces/IFairLaunchV1.sol
@@ -2,13 +2,13 @@ pragma solidity 0.6.6;
 pragma experimental ABIEncoderV2;
 
 interface IFairLaunchV1 {
+  // Data structure
   struct UserInfo {
     uint256 amount;
     uint256 rewardDebt;
     uint256 bonusDebt;
     address fundedBy;
   }
-
   struct PoolInfo {
     address stakeToken;
     uint256 allocPoint;
@@ -17,34 +17,25 @@ interface IFairLaunchV1 {
     uint256 accAlpacaPerShareTilBonusEnd;
   }
 
+  // Information query functions
   function alpacaPerBlock() external view returns (uint256);
   function totalAllocPoint() external view returns (uint256);
   function poolInfo(uint256 pid) external view returns (IFairLaunchV1.PoolInfo memory);
   function userInfo(uint256 pid, address user) external view returns (IFairLaunchV1.UserInfo memory);
-
   function poolLength() external view returns (uint256);
 
-  function addPool(
-    uint256 _allocPoint,
-    address _stakeToken,
-    bool _withUpdate
-  ) external;
+  // OnlyOwner functions
+  function setAlpacaPerBlock(uint256 _alpacaPerBlock) external;
+  function setBonus(uint256 _bonusMultiplier, uint256 _bonusEndBlock, uint256 _bonusLockUpBps) external;
+  function manualMint(address _to, uint256 _amount) external;
+  function addPool(uint256 _allocPoint, address _stakeToken, bool _withUpdate) external;
+  function setPool(uint256 _pid, uint256 _allocPoint, bool _withUpdate) external;
 
-  function setPool(
-    uint256 _pid,
-    uint256 _allocPoint,
-    bool _withUpdate
-  ) external;
-
+  // User's interaction functions
   function pendingAlpaca(uint256 _pid, address _user) external view returns (uint256);
-
   function updatePool(uint256 _pid) external;
-
   function deposit(address _for, uint256 _pid, uint256 _amount) external;
-
   function withdraw(address _for, uint256 _pid, uint256 _amount) external;
-
   function withdrawAll(address _for, uint256 _pid) external;
-
   function harvest(uint256 _pid) external;
 }

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "test:unitwoside": "hardhat test --no-compile ./test/Unisushiswap_StrategyAddTwoSidesOptimal.test.ts",
     "test:router": "hardhat test --no-compile ./test/IbTokenRouter.test.ts",
     "test:timelock": "hardhat test --no-compile ./test/Timelock.test.ts",
+    "test:shield": "hardhat test --no-compile ./test/Shield.test.ts",
     "test:stronkalpaca": "hardhat test --no-compile ./test/StronkAlpaca.test.ts",
     "test": "hardhat test --no-compile",
     "testnet": "hardhat console --no-compile --network testnet",

--- a/test/FairLaunch.test.ts
+++ b/test/FairLaunch.test.ts
@@ -15,7 +15,7 @@ import {
 chai.use(solidity);
 const { expect } = chai;
 
-describe("FairLaunch Proxy", () => {
+describe("FairLaunch", () => {
   const ALPACA_REWARD_PER_BLOCK = ethers.utils.parseEther('5000');
   const ALPACA_BONUS_LOCK_UP_BPS = 7000;
 

--- a/test/Shield.test.ts
+++ b/test/Shield.test.ts
@@ -1,0 +1,402 @@
+import { ethers, upgrades, waffle } from "hardhat";
+import { Overrides, Signer, BigNumberish, utils, Wallet } from "ethers";
+import chai from "chai";
+import { solidity } from "ethereum-waffle";
+import "@openzeppelin/test-helpers";
+import {
+  AlpacaToken,
+  AlpacaToken__factory,
+  FairLaunch,
+  FairLaunch__factory,
+  MockERC20,
+  MockERC20__factory,
+  Shield,
+  Shield__factory,
+  Timelock,
+  Timelock__factory,
+} from "../typechain";
+import * as TimeHelpers from "./helpers/time"
+
+chai.use(solidity);
+const { expect } = chai;
+
+describe("Shield", () => {
+  const ALPACA_REWARD_PER_BLOCK = ethers.utils.parseEther('5000');
+  const ALPACA_BONUS_LOCK_UP_BPS = 7000;
+
+  // Contract as Signer
+  let alpacaTokenAsAlice: AlpacaToken;
+  let alpacaTokenAsBob: AlpacaToken;
+  let alpacaTokenAsDev: AlpacaToken;
+
+  let stoken0AsDeployer: MockERC20;
+  let stoken0AsAlice: MockERC20;
+  let stoken0AsBob: MockERC20;
+  let stoken0AsDev: MockERC20;
+
+  let stoken1AsDeployer: MockERC20;
+  let stoken1AsAlice: MockERC20;
+  let stoken1AsBob: MockERC20;
+  let stoken1AsDev: MockERC20;
+
+  let fairLaunchAsDeployer: FairLaunch;
+  let fairLaunchAsAlice: FairLaunch;
+  let fairLaunchAsBob: FairLaunch;
+  let fairLaunchAsDev: FairLaunch;
+
+  let timelockAsDev: Timelock;
+
+  // Accounts
+  let deployer: Signer;
+  let alice: Signer;
+  let bob: Signer;
+  let dev: Signer;
+
+  // Contracts
+  let alpacaToken: AlpacaToken;
+  let fairLaunch: FairLaunch;
+  let shield: Shield;
+  let stakingTokens: MockERC20[];
+  let timelock: Timelock;
+
+  beforeEach(async() => {
+    [deployer, alice, bob, dev] = await ethers.getSigners();
+
+    // Setup FairLaunch contract
+    // Deploy ALPACAs
+    const AlpacaToken = (await ethers.getContractFactory(
+      "AlpacaToken",
+      deployer
+    )) as AlpacaToken__factory;
+    alpacaToken = await AlpacaToken.deploy(132, 137);
+    await alpacaToken.deployed();
+
+    const FairLaunch = (await ethers.getContractFactory(
+      "FairLaunch",
+      deployer
+    )) as FairLaunch__factory;
+    fairLaunch = await FairLaunch.deploy(
+      alpacaToken.address, (await dev.getAddress()), ALPACA_REWARD_PER_BLOCK, 0, ALPACA_BONUS_LOCK_UP_BPS, 0
+    )
+    await fairLaunch.deployed();
+
+    await alpacaToken.transferOwnership(fairLaunch.address);
+
+    const Timelock = (await ethers.getContractFactory(
+      "Timelock",
+      deployer
+    )) as Timelock__factory;
+    timelock = await Timelock.deploy(await dev.getAddress(), '259200');
+    await timelock.deployed();
+
+    const Shield = (await ethers.getContractFactory(
+      "Shield",
+      deployer
+    )) as Shield__factory;
+    shield = await Shield.deploy(timelock.address, fairLaunch.address);
+    await shield.deployed();
+
+    stakingTokens = new Array();
+    for(let i = 0; i < 4; i++) {
+      const MockERC20 = (await ethers.getContractFactory(
+        "MockERC20",
+        deployer
+      )) as MockERC20__factory;
+      const mockERC20 = await upgrades.deployProxy(MockERC20, [`STOKEN${i}`, `STOKEN${i}`]) as MockERC20;
+      await mockERC20.deployed();
+      stakingTokens.push(mockERC20);
+    }
+
+    alpacaTokenAsAlice = AlpacaToken__factory.connect(alpacaToken.address, alice);
+    alpacaTokenAsBob = AlpacaToken__factory.connect(alpacaToken.address, bob);
+    alpacaTokenAsDev = AlpacaToken__factory.connect(alpacaToken.address, dev);
+
+    stoken0AsDeployer = MockERC20__factory.connect(stakingTokens[0].address, deployer);
+    stoken0AsAlice = MockERC20__factory.connect(stakingTokens[0].address, alice);
+    stoken0AsBob = MockERC20__factory.connect(stakingTokens[0].address, bob);
+    stoken0AsDev = MockERC20__factory.connect(stakingTokens[0].address, dev);
+
+    stoken1AsDeployer = MockERC20__factory.connect(stakingTokens[1].address, deployer);
+    stoken1AsAlice = MockERC20__factory.connect(stakingTokens[1].address, alice);
+    stoken1AsBob = MockERC20__factory.connect(stakingTokens[1].address, bob);
+    stoken1AsDev = MockERC20__factory.connect(stakingTokens[1].address, dev);
+
+    fairLaunchAsDeployer = FairLaunch__factory.connect(fairLaunch.address, deployer);
+    fairLaunchAsAlice = FairLaunch__factory.connect(fairLaunch.address, alice);
+    fairLaunchAsBob = FairLaunch__factory.connect(fairLaunch.address, bob);
+    fairLaunchAsDev = FairLaunch__factory.connect(fairLaunch.address, dev);
+
+    timelockAsDev = Timelock__factory.connect(timelock.address, dev);
+  });
+
+  context("when migrate FairLaunchV1's owner from Timelock to Shield + Timelock", async() => {
+    beforeEach(async() => {
+      await fairLaunch.transferOwnership(timelock.address);
+
+      expect(await fairLaunch.owner()).to.be.eq(timelock.address);
+      expect(await shield.owner()).to.be.eq(timelock.address);
+    });
+
+    it('should revert when non owner to interact with Shield', async() => {
+      await expect(
+        shield.setAlpacaPerBlock(ethers.utils.parseEther('1'))
+      ).to.be.revertedWith('Ownable: caller is not the owner');
+
+      await expect(
+        shield.setBonus(1, 500, 7000)
+      ).to.be.revertedWith('Ownable: caller is not the owner');
+
+      await expect(
+        shield.mintWarchest(await dev.getAddress(), ethers.utils.parseEther('1'))
+      ).to.be.revertedWith('Ownable: caller is not the owner');
+
+      await expect(
+        shield.addPool(1, stakingTokens[0].address, false)
+      ).to.be.revertedWith('Ownable: caller is not the owner');
+
+      await expect(
+        shield.setPool(1, 100, false)
+      ).to.be.revertedWith('Ownable: caller is not the owner');
+    });
+
+    it('should revert when adjust param through Timelock + Shield when migration has not been done', async() => {
+      const eta = (await TimeHelpers.latest()).add(TimeHelpers.duration.days(ethers.BigNumber.from('4')));
+      await timelockAsDev.queueTransaction(
+        shield.address, '0', 'addPool(uint256,address,bool)',
+        ethers.utils.defaultAbiCoder.encode(
+          ['uint256', 'address', 'bool'],
+          [100, stakingTokens[0].address, false]), eta
+      );
+
+      await TimeHelpers.increase(TimeHelpers.duration.days(ethers.BigNumber.from('4')));
+
+      await expect(timelockAsDev.executeTransaction(
+        shield.address, '0', 'addPool(uint256,address,bool)',
+        ethers.utils.defaultAbiCoder.encode(
+          ['uint256', 'address', 'bool'],
+          [100, stakingTokens[0].address, false]), eta
+      )).to.be.revertedWith('Ownable: caller is not the owner');
+    })
+
+    it('should migrate successfully', async() => {
+      const eta = (await TimeHelpers.latest()).add(TimeHelpers.duration.days(ethers.BigNumber.from('4')));
+      await timelockAsDev.queueTransaction(
+        fairLaunch.address, '0', 'transferOwnership(address)',
+        ethers.utils.defaultAbiCoder.encode(
+          ['address'],
+          [shield.address]), eta
+      );
+
+      await TimeHelpers.increase(TimeHelpers.duration.days(ethers.BigNumber.from('4')));
+
+      await timelockAsDev.executeTransaction(
+        fairLaunch.address, '0', 'transferOwnership(address)',
+        ethers.utils.defaultAbiCoder.encode(
+          ['address'],
+          [shield.address]), eta
+      );
+
+      expect(await fairLaunch.owner()).to.be.eq(shield.address);
+    })
+  });
+
+  context("when adjust FairLaunchV1 params via Shield + Timelock", async() => {
+    beforeEach(async() => {
+      await fairLaunch.transferOwnership(shield.address);
+
+      expect(await fairLaunch.owner()).to.be.eq(shield.address);
+      expect(await shield.owner()).to.be.eq(timelock.address);
+    });
+
+    it('should add new pool when Timelock is passed ETA', async() => {
+      const eta = (await TimeHelpers.latest()).add(TimeHelpers.duration.days(ethers.BigNumber.from('4')));
+      await timelockAsDev.queueTransaction(
+        shield.address, '0', 'addPool(uint256,address,bool)',
+        ethers.utils.defaultAbiCoder.encode(
+          ['uint256', 'address', 'bool'],
+          [100, stakingTokens[0].address, false]), eta
+      );
+
+      await TimeHelpers.increase(TimeHelpers.duration.days(ethers.BigNumber.from('4')));
+
+      await timelockAsDev.executeTransaction(
+        shield.address, '0', 'addPool(uint256,address,bool)',
+        ethers.utils.defaultAbiCoder.encode(
+          ['uint256', 'address', 'bool'],
+          [100, stakingTokens[0].address, false]), eta
+      );
+
+      expect((await fairLaunch.poolInfo(0)).allocPoint).to.be.bignumber.eq(100);
+      expect((await fairLaunch.poolInfo(0)).stakeToken).to.be.eq(stakingTokens[0].address);
+    });
+
+    it('should set pool on existed pool when Timelock is passed ETA', async() => {
+      let eta = (await TimeHelpers.latest()).add(TimeHelpers.duration.days(ethers.BigNumber.from('4')));
+      await timelockAsDev.queueTransaction(
+        shield.address, '0', 'addPool(uint256,address,bool)',
+        ethers.utils.defaultAbiCoder.encode(
+          ['uint256', 'address', 'bool'],
+          [100, stakingTokens[0].address, false]), eta
+      );
+
+      await TimeHelpers.increase(TimeHelpers.duration.days(ethers.BigNumber.from('4')));
+
+      await timelockAsDev.executeTransaction(
+        shield.address, '0', 'addPool(uint256,address,bool)',
+        ethers.utils.defaultAbiCoder.encode(
+          ['uint256', 'address', 'bool'],
+          [100, stakingTokens[0].address, false]), eta
+      );
+
+      expect((await fairLaunch.poolInfo(0)).allocPoint).to.be.bignumber.eq(100);
+      expect((await fairLaunch.poolInfo(0)).stakeToken).to.be.eq(stakingTokens[0].address);
+
+      eta = (await TimeHelpers.latest()).add(TimeHelpers.duration.days(ethers.BigNumber.from('4')));
+      await timelockAsDev.queueTransaction(
+        shield.address, '0', 'setPool(uint256,uint256,bool)',
+        ethers.utils.defaultAbiCoder.encode(
+          ['uint256', 'uint256', 'bool'],
+          [0, 200, false]), eta
+      );
+
+      await TimeHelpers.increase(TimeHelpers.duration.days(ethers.BigNumber.from('4')));
+
+      await timelockAsDev.executeTransaction(
+        shield.address, '0', 'setPool(uint256,uint256,bool)',
+        ethers.utils.defaultAbiCoder.encode(
+          ['uint256', 'uint256', 'bool'],
+          [0, 200, false]), eta
+      );
+
+      expect((await fairLaunch.poolInfo(0)).allocPoint).to.be.bignumber.eq(200);
+      expect((await fairLaunch.poolInfo(0)).stakeToken).to.be.eq(stakingTokens[0].address);
+    });
+
+    it('should set bonus on FLV1 when Timelock is passed ETA', async() => {
+      let eta = (await TimeHelpers.latest()).add(TimeHelpers.duration.days(ethers.BigNumber.from('4')));
+      await timelockAsDev.queueTransaction(
+        shield.address, '0', 'setBonus(uint256,uint256,uint256)',
+        ethers.utils.defaultAbiCoder.encode(
+          ['uint256', 'uint256', 'uint256'],
+          [2, 888888, 7000]), eta
+      );
+
+      await TimeHelpers.increase(TimeHelpers.duration.days(ethers.BigNumber.from('4')));
+
+      await timelockAsDev.executeTransaction(
+        shield.address, '0', 'setBonus(uint256,uint256,uint256)',
+        ethers.utils.defaultAbiCoder.encode(
+          ['uint256', 'uint256', 'uint256'],
+          [2, 888888, 7000]), eta
+      );
+
+      expect(await fairLaunch.bonusMultiplier()).to.be.bignumber.eq(2);
+      expect(await fairLaunch.bonusEndBlock()).to.be.bignumber.eq(888888);
+      expect(await fairLaunch.bonusLockUpBps()).to.be.bignumber.eq(7000);
+    });
+
+    it('should set alpaca per block on FLV1 when Timelock is passed ETA', async() => {
+      let eta = (await TimeHelpers.latest()).add(TimeHelpers.duration.days(ethers.BigNumber.from('4')));
+      await timelockAsDev.queueTransaction(
+        shield.address, '0', 'setAlpacaPerBlock(uint256)',
+        ethers.utils.defaultAbiCoder.encode(
+          ['uint256'],
+          [88]), eta
+      );
+
+      await TimeHelpers.increase(TimeHelpers.duration.days(ethers.BigNumber.from('4')));
+
+      await timelockAsDev.executeTransaction(
+        shield.address, '0', 'setAlpacaPerBlock(uint256)',
+        ethers.utils.defaultAbiCoder.encode(
+          ['uint256'],
+          [88]), eta
+      );
+
+      expect(await fairLaunch.alpacaPerBlock()).to.be.bignumber.eq(88);
+    });
+
+    it('should allow to mint Alpaca if mintCount <= 8m', async() => {
+      let eta = (await TimeHelpers.latest()).add(TimeHelpers.duration.days(ethers.BigNumber.from('4')));
+      await timelockAsDev.queueTransaction(
+        shield.address, '0', 'mintWarchest(address,uint256)',
+        ethers.utils.defaultAbiCoder.encode(
+          ['address','uint256'],
+          [await alice.getAddress(), ethers.utils.parseEther('2750000')]), eta
+      );
+
+      await TimeHelpers.increase(TimeHelpers.duration.days(ethers.BigNumber.from('4')));
+
+      await timelockAsDev.executeTransaction(
+        shield.address, '0', 'mintWarchest(address,uint256)',
+        ethers.utils.defaultAbiCoder.encode(
+          ['address','uint256'],
+          [await alice.getAddress(), ethers.utils.parseEther('2750000')]), eta
+      );
+
+      expect(await shield.mintCount()).to.be.bignumber.eq(ethers.utils.parseEther('3000000'));
+      expect(await alpacaToken.balanceOf(await alice.getAddress())).to.be.bignumber.eq(ethers.utils.parseEther('2750000'));
+
+      eta = (await TimeHelpers.latest()).add(TimeHelpers.duration.days(ethers.BigNumber.from('4')));
+      await timelockAsDev.queueTransaction(
+        shield.address, '0', 'mintWarchest(address,uint256)',
+        ethers.utils.defaultAbiCoder.encode(
+          ['address','uint256'],
+          [await alice.getAddress(), ethers.utils.parseEther('5000000')]), eta
+      );
+
+      await TimeHelpers.increase(TimeHelpers.duration.days(ethers.BigNumber.from('4')));
+
+      await timelockAsDev.executeTransaction(
+        shield.address, '0', 'mintWarchest(address,uint256)',
+        ethers.utils.defaultAbiCoder.encode(
+          ['address','uint256'],
+          [await alice.getAddress(), ethers.utils.parseEther('5000000')]), eta
+      );
+
+      expect(await shield.mintCount()).to.be.bignumber.eq(ethers.utils.parseEther('8000000'));
+      expect(await alpacaToken.balanceOf(await alice.getAddress())).to.be.bignumber.eq(ethers.utils.parseEther('7750000'));
+    });
+
+    it('should revert when mintCount > 8m', async() => {
+      let eta = (await TimeHelpers.latest()).add(TimeHelpers.duration.days(ethers.BigNumber.from('4')));
+      await timelockAsDev.queueTransaction(
+        shield.address, '0', 'mintWarchest(address,uint256)',
+        ethers.utils.defaultAbiCoder.encode(
+          ['address','uint256'],
+          [await alice.getAddress(), ethers.utils.parseEther('2750000')]), eta
+      );
+
+      await TimeHelpers.increase(TimeHelpers.duration.days(ethers.BigNumber.from('4')));
+
+      await timelockAsDev.executeTransaction(
+        shield.address, '0', 'mintWarchest(address,uint256)',
+        ethers.utils.defaultAbiCoder.encode(
+          ['address','uint256'],
+          [await alice.getAddress(), ethers.utils.parseEther('2750000')]), eta
+      );
+
+      expect(await shield.mintCount()).to.be.bignumber.eq(ethers.utils.parseEther('3000000'));
+      expect(await alpacaToken.balanceOf(await alice.getAddress())).to.be.bignumber.eq(ethers.utils.parseEther('2750000'));
+
+      eta = (await TimeHelpers.latest()).add(TimeHelpers.duration.days(ethers.BigNumber.from('4')));
+      await timelockAsDev.queueTransaction(
+        shield.address, '0', 'mintWarchest(address,uint256)',
+        ethers.utils.defaultAbiCoder.encode(
+          ['address','uint256'],
+          [await alice.getAddress(), ethers.utils.parseEther('5000001')]), eta
+      );
+
+      await TimeHelpers.increase(TimeHelpers.duration.days(ethers.BigNumber.from('4')));
+
+      await expect(timelockAsDev.executeTransaction(
+        shield.address, '0', 'mintWarchest(address,uint256)',
+        ethers.utils.defaultAbiCoder.encode(
+          ['address','uint256'],
+          [await alice.getAddress(), ethers.utils.parseEther('5000001')]), eta
+      )).to.be.revertedWith('shield: mint exceeded mintLimit');
+      expect(await shield.mintCount()).to.be.bignumber.eq(ethers.utils.parseEther('3000000'));
+      expect(await alpacaToken.balanceOf(await alice.getAddress())).to.be.bignumber.eq(ethers.utils.parseEther('2750000'));
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Add Shield to protect malicious attempt to mint ALPACA over war chest amount. 

## Why?
Because in AlpacaToken.sol `manualMint` variable doesn't get updated when the war chest portion has been minted. Hence `Shield.sol` is needed to be placed on FairLaunchV1 in order to prevent maliciously attempt to mint ALPACA over the limit.

## ChangeLogs:
- Add Shield.sol
- Add Shield.test.ts
