### PR TITLE
fix: check user balance before unhodl

### DIFF
--- a/contracts/6/token/StronkAlpaca.sol
+++ b/contracts/6/token/StronkAlpaca.sol
@@ -54,8 +54,9 @@ contract StronkAlpaca is IStronkAlpaca, ERC20("Stronk Alpaca", "sALPACA"), Ownab
 
   function prepareHodl() external override onlyEOA nonReentrant {
     require(_userRelayerMap[msg.sender] == address(0), "StronkAlpaca::prepareHodl: user has already prepared hodl");
-    require(block.number > hodlableStartBlock, "StronkAlpaca::prepareHodl: block.number not reach hodlableStartBlock");
+    require(block.number >= hodlableStartBlock, "StronkAlpaca::prepareHodl: block.number not reach hodlableStartBlock");
     require(block.number < hodlableEndBlock, "StronkAlpaca::prepareHodl: block.number exceeds hodlableEndBlock");
+    require(IAlpacaToken(alpacaTokenAddress).lockOf(msg.sender) > 0, "StronkAlpaca::preparehodl: user's lockAlpaca must be greater than zero");
 
     // create relayer contract
     StronkAlpacaRelayer relayer = new StronkAlpacaRelayer(alpacaTokenAddress, msg.sender);
@@ -82,8 +83,6 @@ contract StronkAlpaca is IStronkAlpaca, ERC20("Stronk Alpaca", "sALPACA"), Ownab
       "StronkAlpaca::unhodl: block.number have not reach alpacaToken.endReleaseBlock"
     );
     require(block.number > lockEndBlock, "StronkAlpaca::unhodl: block.number have not reach lockEndBlock");
-
-    require(balanceOf(msg.sender) > 0, "StronkAlpaca::unhodl: user's sAlpaca must be greater than zero");
 
     // unlock all the Alpaca token in case it never have been unlocked yet
     // Note: given that releasePeriodEnd has passed, so that locked token has been 100% released

--- a/deploy/012_deploy_stronk_alpaca.ts
+++ b/deploy/012_deploy_stronk_alpaca.ts
@@ -15,6 +15,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   */
 
   const ALPACA_TOKEN_ADDR = '0x19C64173a4fD5C2Db375f68444B2aA3070e0de08';
+  const HODLABLE_START_BLOCK = '5311496'
   const HODLABLE_END_BLOCK = '5411496'; // hodl can be called until this block
   const LOCK_END_BLOCK = '5511496'; // unhodl can be called after this block
 
@@ -33,6 +34,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const StronkAlpaca = (await ethers.getContractFactory(   "StronkAlpaca",    (await ethers.getSigners())[0],  )) as StronkAlpaca__factory;
   const stronkAlpaca = await StronkAlpaca.deploy(
     ALPACA_TOKEN_ADDR,
+    ethers.BigNumber.from(HODLABLE_START_BLOCK),
     ethers.BigNumber.from(HODLABLE_END_BLOCK),
     ethers.BigNumber.from(LOCK_END_BLOCK),
   );

--- a/test/StronkAlpaca.test.ts
+++ b/test/StronkAlpaca.test.ts
@@ -147,6 +147,10 @@ describe("StronkAlpaca and StronkAlpacaRelayer", () => {
 
   context('when alice has already called prepareHodl once', async () => {
     it('should not allow to prepareHodl when user has already prepare hodl', async () => {
+      const aliceAddress = await alice.getAddress()
+      //100 alpaca to alice and then lock with 100
+      await alpacaToken.mint(aliceAddress, ethers.utils.parseEther('100'))
+      await alpacaToken.lock(aliceAddress, ethers.utils.parseEther('100'))
       // Advance 50 blocks to reach holdStartBlock
       await TimeHelpers.advanceBlockTo(nowBlock + 50)
       await stronkAlpacaAsAlice.prepareHodl()
@@ -166,10 +170,26 @@ describe("StronkAlpaca and StronkAlpacaRelayer", () => {
 
   context('when alice want to hodl StronkAlpaca after hodlableEndBlock', async () => {
     it('should not allow to do so when block.number exceeds hodlableEndBlock', async () => {
+      const aliceAddress = await alice.getAddress()
+      //100 alpaca to alice and then lock with 100
+      await alpacaToken.mint(aliceAddress, ethers.utils.parseEther('100'))
+      await alpacaToken.lock(aliceAddress, ethers.utils.parseEther('100'))
+      //Advance block to not be able to hodl
       await TimeHelpers.advanceBlockTo(nowBlock + 100)
       await expect(stronkAlpacaAsAlice.prepareHodl())
         .to.be
         .revertedWith('StronkAlpaca::prepareHodl: block.number exceeds hodlableEndBlock')
+    })
+    it(`should not allow to do so before balance of user's lockAlpaca is zero or less than zero`, async () => {
+      const aliceAddress = await alice.getAddress()
+      //100 alpaca to alice and then lock with 0
+      await alpacaToken.mint(aliceAddress, ethers.utils.parseEther('100'))
+      await alpacaToken.lock(aliceAddress, ethers.utils.parseEther('0'))
+      //Advance block to be able to prepareHodl
+      await TimeHelpers.advanceBlockTo(nowBlock + 50)
+      await expect(stronkAlpacaAsAlice.prepareHodl())
+      .to.be.
+      revertedWith(`StronkAlpaca::preparehodl: user's lockAlpaca must be greater than zero`)
     })
   })
 
@@ -184,6 +204,9 @@ describe("StronkAlpaca and StronkAlpacaRelayer", () => {
   context('when the relayer is created (prepareHodl)', async() => {
     it('should allow transferAllAlpaca to be called by only StronkAlpaca contract', async () => {
       const aliceAddress = await alice.getAddress()
+      //100 alpaca to alice and then lock.
+      await alpacaToken.mint(aliceAddress, ethers.utils.parseEther('100'))
+      await alpacaToken.lock(aliceAddress, ethers.utils.parseEther('100'))
       // Advance 50 blocks to reach holdStartBlock
       await TimeHelpers.advanceBlockTo(nowBlock + 50)
       await stronkAlpacaAsAlice.prepareHodl()
@@ -285,13 +308,5 @@ describe("StronkAlpaca and StronkAlpacaRelayer", () => {
         .to.be
         .revertedWith('StronkAlpaca::unhodl: block.number have not reach lockEndBlock')
     })
-
-    it(`should not allow to do so before balance of user's sAlpaca is zero or less than zero`, async () => {
-      await TimeHelpers.advanceBlockTo(nowBlock + 500)
-      await expect(stronkAlpacaAsAlice.unhodl())
-      .to.be.
-      revertedWith(`StronkAlpaca::unhodl: user's sAlpaca must be greater than zero`)
-    })
-
   })
 })


### PR DESCRIPTION
feat: add start hodlableStartBlock

<!--- PLEASE FOLLOW THE GUIDELINE -->

## Description
<!--- Describe your changes in detail -->
- Check user's balance before unhodl sAlpaca.
- Add hodlableStartBlock time.


## Why?
<!--- Why is this change required? What problem does it solve? -->
- Check user's balance before unhodl sAlpaca: To ensure that user has sAlpaca to unhodl.
- Add hodlableStartBlock time: to add more control on when to start the strongHodl.

## ChangeLogs:
<!--- changes for this pr -->
- StronkAlpaca.sol
- StronkAlpaca.test.ts

### Link to story (if available)
<!--- Add story URL here -->
