### PR TITLE
feat: optimize approval pancakeswapworker

### DIFF
--- a/contracts/6/protocol/workers/PancakeswapWorker.sol
+++ b/contracts/6/protocol/workers/PancakeswapWorker.sol
@@ -117,7 +117,7 @@ contract PancakeswapWorker is OwnableUpgradeSafe, ReentrancyGuardUpgradeSafe, IW
   function reinvest() public override onlyEOA nonReentrant {
     // 1. Approve tokens
     cake.safeApprove(address(router), uint256(-1));
-    lpToken.approve(address(masterChef), uint256(-1));
+    address(lpToken).safeApprove(address(masterChef), uint256(-1));
     // 2. Withdraw all the rewards.
     masterChef.withdraw(pid, 0);
     uint256 reward = cake.balanceOf(address(this));
@@ -145,7 +145,7 @@ contract PancakeswapWorker is OwnableUpgradeSafe, ReentrancyGuardUpgradeSafe, IW
     masterChef.deposit(pid, lpToken.balanceOf(address(this)));
     // 7. Reset approve
     cake.safeApprove(address(router), 0);
-    lpToken.approve(address(masterChef), 0);
+    address(lpToken).safeApprove(address(masterChef), 0);
     emit Reinvest(msg.sender, reward, bounty);
   }
 
@@ -222,7 +222,7 @@ contract PancakeswapWorker is OwnableUpgradeSafe, ReentrancyGuardUpgradeSafe, IW
     uint256 balance = lpToken.balanceOf(address(this));
     if (balance > 0) {
       // 1. Approve token to be spend by masterChef
-      lpToken.approve(address(masterChef), uint256(-1));
+      address(lpToken).safeApprove(address(masterChef), uint256(-1));
       // 2. Convert balance to share
       uint256 share = balanceToShare(balance);
       // 3. Deposit balance to PancakeMasterChef
@@ -231,7 +231,7 @@ contract PancakeswapWorker is OwnableUpgradeSafe, ReentrancyGuardUpgradeSafe, IW
       shares[id] = shares[id].add(share);
       totalShare = totalShare.add(share);
       // 5. Reset approve token
-      lpToken.approve(address(masterChef), 0);
+      address(lpToken).safeApprove(address(masterChef), 0);
       emit AddShare(id, share);
     }
   }

--- a/contracts/6/protocol/workers/PancakeswapWorker.sol
+++ b/contracts/6/protocol/workers/PancakeswapWorker.sol
@@ -81,10 +81,6 @@ contract PancakeswapWorker is OwnableUpgradeSafe, ReentrancyGuardUpgradeSafe, IW
     okStrats[address(liqStrat)] = true;
     reinvestBountyBps = _reinvestBountyBps;
     maxReinvestBountyBps = 500;
-    lpToken.approve(address(_masterChef), uint256(-1)); // 100% trust in the staking pool
-    lpToken.approve(address(router), uint256(-1)); // 100% trust in the router
-    quoteToken.safeApprove(address(router), uint256(-1)); // 100% trust in the router
-    cake.safeApprove(address(router), uint256(-1)); // 100% trust in the router
 
     require(reinvestBountyBps <= maxReinvestBountyBps, "PancakeswapWorker::initialize:: reinvestBountyBps exceeded maxReinvestBountyBps");
   }
@@ -119,14 +115,17 @@ contract PancakeswapWorker is OwnableUpgradeSafe, ReentrancyGuardUpgradeSafe, IW
 
   /// @dev Re-invest whatever this worker has earned back to staked LP tokens.
   function reinvest() public override onlyEOA nonReentrant {
-    // 1. Withdraw all the rewards.
+    // 1. Approve tokens
+    cake.safeApprove(address(router), uint256(-1));
+    lpToken.approve(address(masterChef), uint256(-1));
+    // 2. Withdraw all the rewards.
     masterChef.withdraw(pid, 0);
     uint256 reward = cake.balanceOf(address(this));
     if (reward == 0) return;
-    // 2. Send the reward bounty to the caller.
+    // 3. Send the reward bounty to the caller.
     uint256 bounty = reward.mul(reinvestBountyBps) / 10000;
     if (bounty > 0) cake.safeTransfer(msg.sender, bounty);
-    // 3. Convert all the remaining rewards to BaseToken via Native for liquidity.
+    // 4. Convert all the remaining rewards to BaseToken via Native for liquidity.
     address[] memory path;
     if (baseToken == wNative) {
       path = new address[](2);
@@ -139,11 +138,14 @@ contract PancakeswapWorker is OwnableUpgradeSafe, ReentrancyGuardUpgradeSafe, IW
       path[2] = address(baseToken);
     }
     router.swapExactTokensForTokens(reward.sub(bounty), 0, path, address(this), now);
-    // 4. Use add Token strategy to convert all BaseToken to LP tokens.
+    // 5. Use add Token strategy to convert all BaseToken to LP tokens.
     baseToken.safeTransfer(address(addStrat), baseToken.myBalance());
     addStrat.execute(address(0), 0, abi.encode(baseToken, quoteToken, 0));
-    // 5. Mint more LP tokens and stake them for more rewards.
+    // 6. Mint more LP tokens and stake them for more rewards.
     masterChef.deposit(pid, lpToken.balanceOf(address(this)));
+    // 7. Reset approve
+    cake.safeApprove(address(router), 0);
+    lpToken.approve(address(masterChef), 0);
     emit Reinvest(msg.sender, reward, bounty);
   }
 
@@ -219,10 +221,17 @@ contract PancakeswapWorker is OwnableUpgradeSafe, ReentrancyGuardUpgradeSafe, IW
   function _addShare(uint256 id) internal {
     uint256 balance = lpToken.balanceOf(address(this));
     if (balance > 0) {
+      // 1. Approve token to be spend by masterChef
+      lpToken.approve(address(masterChef), uint256(-1));
+      // 2. Convert balance to share
       uint256 share = balanceToShare(balance);
+      // 3. Deposit balance to PancakeMasterChef
       masterChef.deposit(pid, balance);
+      // 4. Update shares
       shares[id] = shares[id].add(share);
       totalShare = totalShare.add(share);
+      // 5. Reset approve token
+      lpToken.approve(address(masterChef), 0);
       emit AddShare(id, share);
     }
   }

--- a/test/FairLaunchV2.test.ts
+++ b/test/FairLaunchV2.test.ts
@@ -770,13 +770,13 @@ describe("FairLaunchV2", () => {
       await fairLaunch.setPool(0, 0, false);
 
       // 12. Alice & Bob exit FLV1
-      // Alice +10,000+2,500
-      // Bob +2,500
+      // Alice +10,000+2,500+2,500
+      // Bob +2,500+2,500
       await fairLaunchAsAlice.withdraw(await alice.getAddress(), 0, ethers.utils.parseEther('100'));
       await fairLaunchAsBob.withdraw(await bob.getAddress(), 0, ethers.utils.parseEther('100'));
-      expect(await alpacaToken.balanceOf(await alice.getAddress())).to.be.bignumber.eq(ethers.utils.parseEther('27500'));
-      expect(await alpacaToken.balanceOf(await bob.getAddress())).to.be.bignumber.eq(ethers.utils.parseEther('2500'));
-      expect(await alpacaToken.balanceOf((await dev.getAddress()))).to.be.bignumber.eq(ethers.utils.parseEther('3000'));
+      expect(await alpacaToken.balanceOf(await alice.getAddress())).to.be.bignumber.eq(ethers.utils.parseEther('30000'));
+      expect(await alpacaToken.balanceOf(await bob.getAddress())).to.be.bignumber.eq(ethers.utils.parseEther('5000'));
+      expect(await alpacaToken.balanceOf((await dev.getAddress()))).to.be.bignumber.eq(ethers.utils.parseEther('3500'));
 
       // 13. Initialized fairLaunchV2
       await fairLaunchLink.mint(await deployer.getAddress(), ethers.utils.parseEther('1'));
@@ -800,7 +800,7 @@ describe("FairLaunchV2", () => {
       // expect dev token to be the same amount as no alpaca has been mint
       expect(await fairLaunchV2.pendingAlpaca(0, await alice.getAddress())).to.be.bignumber.eq(ethers.utils.parseEther('0'));
       expect(await fairLaunchV2.pendingAlpaca(0, await alice.getAddress())).to.be.bignumber.eq(ethers.utils.parseEther('0'));
-      expect(await alpacaToken.balanceOf(await dev.getAddress())).to.be.bignumber.eq(ethers.utils.parseEther('3000'));
+      expect(await alpacaToken.balanceOf(await dev.getAddress())).to.be.bignumber.eq(ethers.utils.parseEther('3500'));
 
       await fairLaunchV2.init(fairLaunchLink.address);
 
@@ -815,14 +815,14 @@ describe("FairLaunchV2", () => {
       // Check pendingAlpaca for Alice & Bob
       expect(await fairLaunchV2.pendingAlpaca(0, (await alice.getAddress()))).to.be.bignumber.eq(ethers.utils.parseEther('7500'));
       expect(await fairLaunchV2.pendingAlpaca(0, (await alice.getAddress()))).to.be.bignumber.eq(ethers.utils.parseEther('7500'));
-      expect(await alpacaToken.balanceOf((await dev.getAddress()))).to.be.bignumber.eq(ethers.utils.parseEther('4000'));
-
-      // 21. Alice should get 5,000 ALPACAs when she harvest
-      // also check that dev got his tax
-      // PS. Dev get 5,500 as mining continue 2 blocks earlier
-      await fairLaunchV2AsAlice.harvest(0);
-      expect(await alpacaToken.balanceOf((await alice.getAddress()))).to.be.bignumber.eq(ethers.utils.parseEther('37500'));
       expect(await alpacaToken.balanceOf((await dev.getAddress()))).to.be.bignumber.eq(ethers.utils.parseEther('4500'));
+
+      // 21. Alice should get 10,000 ALPACAs when she harvest
+      // also check that dev got his tax
+      // PS. Dev get 5,000 as mining continue 2 blocks earlier
+      await fairLaunchV2AsAlice.harvest(0);
+      expect(await alpacaToken.balanceOf((await alice.getAddress()))).to.be.bignumber.eq(ethers.utils.parseEther('40000'));
+      expect(await alpacaToken.balanceOf((await dev.getAddress()))).to.be.bignumber.eq(ethers.utils.parseEther('5000'));
     })
   })
 });


### PR DESCRIPTION
## Description
Optimize approval PancakeswapWorker. Changing from excessive overflow approve at initializing to approve only when it is needed.

## Why?
Better handling of approval. Prevent such an unforeseeable event when something happens on PCS.

## ChangeLogs:
- PancakeswapWorker.sol
